### PR TITLE
[xcvrd] Handle platfom_chassis None scenario to protect xcvrd from crash

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -205,6 +205,20 @@ class TestXcvrdThreadException(object):
 
 class TestXcvrdScript(object):
 
+    from sonic_platform_base.sonic_xcvr.api.public.c_cmis import CCmisApi
+    from sonic_platform_base.sonic_xcvr.api.public.sff8636 import Sff8636Api
+    from sonic_platform_base.sonic_xcvr.api.public.sff8436 import Sff8436Api
+    @pytest.mark.parametrize("mock_class, expected_return_value", [
+        (CmisApi, True),
+        (CCmisApi, True),
+        (Sff8636Api, False),
+        (Sff8436Api, False)
+    ])
+    def test_is_cmis_api(self, mock_class, expected_return_value):
+        mock_xcvr_api = MagicMock()
+        mock_xcvr_api.__class__ = mock_class
+        assert is_cmis_api(mock_xcvr_api) == expected_return_value
+
     @patch('xcvrd.xcvrd._wrapper_get_sfp_type')
     @patch('xcvrd.xcvrd_utilities.port_mapping.PortMapping.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
     @patch('xcvrd.xcvrd._wrapper_get_presence', MagicMock(return_value=True))

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -109,7 +109,7 @@ helper_logger = logger.Logger(SYSLOG_IDENTIFIER)
 
 
 def is_cmis_api(api):
-   return type(api) == CmisApi
+   return isinstance(api, CmisApi)
 
 
 def get_cmis_application_desired(api, host_lane_count, speed):

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
@@ -52,6 +52,8 @@ def get_lane_speed_key(physical_port, port_speed, lane_count):
                 host_electrical_interface_id = appl_adv_dict[app_id].get('host_electrical_interface_id')
                 if host_electrical_interface_id:
                     lane_speed_key = LANE_SPEED_KEY_PREFIX + host_electrical_interface_id.split()[0]
+    else:
+        helper_logger.log_error("Unable to derive lane_speed_key because platform_chassis is None")
 
     return lane_speed_key
 
@@ -83,6 +85,8 @@ def get_media_settings_key(physical_port, transceiver_dict, port_speed, lane_cou
                 media_compliance_dict = ast.literal_eval(media_compliance_dict_str)
                 if sup_compliance_str in media_compliance_dict:
                     media_compliance_code = media_compliance_dict[sup_compliance_str]
+        else:
+            helper_logger.log_error("Unable to derive media_key.media_compliance_code because platform_chassis is None")
     except ValueError as e:
         helper_logger.log_error("Invalid value for port {} 'specification_compliance': {}".format(physical_port, media_compliance_dict_str))
 
@@ -102,6 +106,8 @@ def get_media_settings_key(physical_port, transceiver_dict, port_speed, lane_cou
             else:
                 if media_len != 0:
                     media_key += '-' + str(media_len) + 'M'
+        else:
+            helper_logger.log_error("Unable to derive media_key.media_len because platform_chassis is None")
     else:
         media_key += '-' + '*'
 


### PR DESCRIPTION
 Added functionality to media_settings_parser to handle the case where platform_chassis is None

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Added validation that the platform_chassis exists before accessing it
-->

#### Motivation and Context
<!--
    To avoid redundant exception thrown in such scenario
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
