### PR TITLE
Updated supported CMIS module types in xcvrd to include new module: OSFP-8X

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -759,7 +759,7 @@ class CmisManagerTask(threading.Thread):
 
     CMIS_MAX_RETRIES     = 3
     CMIS_DEF_EXPIRED     = 60 # seconds, default expiration time
-    CMIS_MODULE_TYPES    = ['QSFP-DD', 'QSFP_DD', 'OSFP', 'QSFP+C']
+    CMIS_MODULE_TYPES    = ['QSFP-DD', 'QSFP_DD', 'OSFP', 'OSFP-8X', 'QSFP+C']
     CMIS_MAX_HOST_LANES    = 8
 
     CMIS_STATE_UNKNOWN   = 'UNKNOWN'


### PR DESCRIPTION
A new cable was added to the list of supported CMIS modules

#### Motivation and Context
In xcvrd, within the CmisManagerTask thread, there is a list of supported CMIS modules. The CMIS state machine only 
starts for modules found in this list. Currently, a certain type of CMIS module, OSFP-8X, is missing from this list. Hence, the 
configuration for such modules will be skipped by the CmisManagerTask.


#### How Has This Been Tested?
I confirmed that when an OSFP-8X module is plugged in, the CMIS state machine is triggered, and the module SI 
parameters are retrieved from optics_si_settings.json and configured successfully.

#### Additional Information (Optional)
