### PR TITLE
Port SI per speed - SFF optics

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -35,6 +35,9 @@ try:
     from .xcvrd_utilities import optics_si_parser
     
     from sonic_platform_base.sonic_xcvr.api.public.c_cmis import CmisApi
+    from sonic_platform_base.sonic_xcvr.api.public.sff8436 import Sff8436Api
+    from sonic_platform_base.sonic_xcvr.api.public.sff8636 import Sff8636Api
+
 
 except ImportError as e:
     raise ImportError(str(e) + " - required module not found")
@@ -105,6 +108,9 @@ helper_logger = logger.Logger(SYSLOG_IDENTIFIER)
 # Helper functions =============================================================
 #
 
+
+def is_sff_api(api):
+    return isinstance(api, Sff8636Api) or isinstance(api, Sff8436Api)
 
 def is_cmis_api(api):
    return isinstance(api, CmisApi)

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
@@ -51,6 +51,9 @@ def get_lane_speed_key(physical_port, port_speed, lane_count):
             host_electrical_interface_id = appl_adv_dict[app_id].get('host_electrical_interface_id')
             if host_electrical_interface_id:
                 lane_speed_key = LANE_SPEED_KEY_PREFIX + host_electrical_interface_id.split()[0]
+    elif xcvrd.is_sff_api(api):
+        lane_speed = int(port_speed) // lane_count
+        lane_speed_key = LANE_SPEED_KEY_PREFIX + str(lane_speed // 1000) + "G"
 
     return lane_speed_key
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Added functionality to calculate lane speed keys for SFF optic modules

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
