### PR TITLE
Fix for 'log_notifce()' typo in xcvrd.py

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1479,7 +1479,7 @@ class CmisManagerTask(threading.Thread):
                         if True == self.is_appl_reconfigure_required(api, appl):
                             self.log_notice("{}: Decommissioning all lanes/datapaths to default AppSel=0".format(lport))
                             if True != api.decommission_all_datapaths():
-                                self.log_notifce("{}: Failed to default to AppSel=0".format(lport))
+                                self.log_notice("{}: Failed to default to AppSel=0".format(lport))
                                 self.force_cmis_reinit(lport, retries + 1)
                                 continue
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Typo fix: log_noti**f**ce() --> log_notice()

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
