### PR TITLE
Avoid loading media_settings.json on mellanox platforms if the host cmis management feature is disabled

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
@@ -6,6 +6,7 @@ import json
 import os
 import ast
 
+from sonic_platform.device_data import DeviceDataManager
 from sonic_py_common import device_info, logger
 from swsscommon import swsscommon
 from xcvrd import xcvrd
@@ -22,6 +23,11 @@ helper_logger = logger.Logger(SYSLOG_IDENTIFIER)
 
 def load_media_settings():
     global g_dict
+
+    if device_info.get_sonic_version_info()['asic_type'] == 'mellanox':
+        if not DeviceDataManager.is_module_host_management_mode():
+            return {}
+
     (platform_path, hwsku_path) = device_info.get_paths_to_platform_and_hwsku_dirs()
 
     # Support to fetch media_settings.json both from platform folder and HWSKU folder

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
@@ -6,7 +6,6 @@ import json
 import os
 import ast
 
-from sonic_platform.device_data import DeviceDataManager
 from sonic_py_common import device_info, logger
 from swsscommon import swsscommon
 from xcvrd import xcvrd
@@ -24,7 +23,9 @@ helper_logger = logger.Logger(SYSLOG_IDENTIFIER)
 def load_media_settings():
     global g_dict
 
-    if device_info.get_sonic_version_info()['asic_type'] == 'mellanox':
+    version_info = device_info.get_sonic_version_info()
+    if version_info and version_info['asic_type'] == 'mellanox':
+        from sonic_platform.device_data import DeviceDataManager
         if not DeviceDataManager.is_module_host_management_mode():
             return {}
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
I added a check to ensure that the media settings JSON is not loaded when the host CMIS management feature is disabled. This prevents unnecessary port-side configurations and potential errors when the feature is not in use.


#### Motivation and Context
Currently, the xcvrd code always posts the SI parameters from media_settings.json to APP_DB. On Mellanox platforms, this process is required only if the Host CMIS Management feature is enabled. If the feature is disabled when media_settings.json is present on the platform and notify_media_settings() is triggered, it can cause containers to crash or links to flap. This is why I added a check to ensure that on Mellanox platforms, media_settings.json is not loaded if the Host CMIS Management feature is disabled.


#### How Has This Been Tested?
Manual tests to ensure that containers do not crash when the feature is disabled and media_settings.json exists on the platform.

#### Additional Information (Optional)
